### PR TITLE
Add Preview Mode / Set feed URL for tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,11 @@
     {% include_sass style.scss %}
     </style>
     {% seo %}
-    {% feed_meta %}
+    {% if page.type == "tag" %}
+      <link type="application/atom+xml" rel="alternate" href="{{ site.url }}/feed/by_tag/{{ page.title }}.xml" title="Toshimaru's Blog - {{ page.title }}" />
+    {% else %}
+      {% feed_meta %}
+    {% endif %}
   </head>
   <body>
     <amp-analytics type="googleanalytics" id="analytics1">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,9 +19,9 @@
     {% include_sass style.scss %}
     </style>
     {% seo %}
-    {%- if page.type == "tag" -%}
+    {%- if page.type == "tag" %}
       <link type="application/atom+xml" rel="alternate" href="{{ site.url }}/feed/by_tag/{{ page.title }}.xml" title="Toshimaru's Blog - {{ page.title }}" />
-    {%- else -%}
+    {%- else %}
       {% feed_meta %}
     {%- endif %}
     {% if jekyll.environment == "preview" %}<meta name="robots" content="noindex {{ jekyll.environment }}">{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,11 +19,12 @@
     {% include_sass style.scss %}
     </style>
     {% seo %}
-    {% if page.type == "tag" %}
+    {%- if page.type == "tag" -%}
       <link type="application/atom+xml" rel="alternate" href="{{ site.url }}/feed/by_tag/{{ page.title }}.xml" title="Toshimaru's Blog - {{ page.title }}" />
-    {% else %}
+    {%- else -%}
       {% feed_meta %}
-    {% endif %}
+    {%- endif %}
+    {% if jekyll.environment == "preview" %}<meta name="robots" content="noindex {{ jekyll.environment }}">{% endif %}
   </head>
   <body>
     <amp-analytics type="googleanalytics" id="analytics1">


### PR DESCRIPTION
Add preview mode to prevent crawlers from indexing the production build.

IN addition to that, add tag feed meta.

## Resource

- [Cloudflare Pages](https://pages.cloudflare.com/)